### PR TITLE
Properties to labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ handler = logging_loki.LokiHandler(
     tags={"application": "my-app"},
     headers={"X-Scope-OrgID": "example-id"},
     auth=("username", "password"),
-    props_to_labels: Optional[list[str]] = ["foo"]
+    props_to_labels = ["foo"]
 )
 
 logger = logging.getLogger("my-logger")
@@ -43,6 +43,26 @@ Example above will send `Something happened` message along with these labels:
 - Message level as `serverity`
 - Logger's name as `logger`
 - Labels from `tags` item of `extra` dict
+- Property `foo` from log record will be sent as loki label
+
+## Properties to label
+
+Using a dict instead of a list for `props_to_labels` will enable renaming labels
+
+```python
+handler = logging_loki.LokiHandler(
+    url="https://my-loki-instance/loki/api/v1/push",
+    tags={"application": "my-app"},
+    props_to_labels = {
+        "otelTraceID": "trace_id"
+        "otelSpanID":  "span_id"
+    }
+)
+```
+
+In this case, the properties `otelTraceID` & `otelSpanID` will be renamed to `trace_id` & `span_id` loki labels
+
+## Non-blocking mode
 
 The given example is blocking (i.e. each call will wait for the message to be sent).  
 But you can use the built-in `QueueHandler` and` QueueListener` to send messages in a separate thread.

--- a/logging_loki/emitter.py
+++ b/logging_loki/emitter.py
@@ -133,9 +133,9 @@ class LokiEmitter:
             for k in self.props_to_labels:
                 if prop_value := getattr(record, k, None) or jsonline.get(k, None):
                     if isinstance(self.props_to_labels, list):
-                        extra_tags.update({k: prop_value})
+                        extra_tags.update({k: str(prop_value)})
                     else:
-                        extra_tags.update({self.props_to_labels[k]: prop_value})
+                        extra_tags.update({self.props_to_labels[k]: str(prop_value)})
         if isinstance(passed_tags := getattr(record, "tags", {}), dict):
             extra_tags = extra_tags | passed_tags
 

--- a/logging_loki/emitter.py
+++ b/logging_loki/emitter.py
@@ -129,7 +129,7 @@ class LokiEmitter:
 
         extra_tags = {}
         if self.props_to_labels:
-            jsonline = json.loads(line)
+            jsonline = json.loads(line) if self.as_json else {}
             for k in self.props_to_labels:
                 if prop_value := getattr(record, k, None) or jsonline.get(k, None):
                     extra_tags.update({k: prop_value})

--- a/logging_loki/emitter.py
+++ b/logging_loki/emitter.py
@@ -43,7 +43,7 @@ class LokiEmitter:
         headers: Optional[dict] = None, 
         auth: BasicAuth = None, 
         as_json: bool = False,
-        props_to_labels: Optional[list[str]] = None,
+        props_to_labels: Optional[list[str] | dict] = None,
         level_tag: Optional[str] = const.level_tag,
         logger_tag: Optional[str] = const.logger_tag,
         verify: Union[bool, str] = True
@@ -67,7 +67,7 @@ class LokiEmitter:
         self.auth = auth
         #: Optional bool, send record as json?
         self.as_json = as_json
-        #: Optional list, convert properties to loki labels
+        #: Optional list, convert properties to loki labels or dict to remap original properties to loki labels
         self.props_to_labels = props_to_labels or []
         #: Label name indicating logging level.
         self.level_tag: str = level_tag
@@ -132,7 +132,10 @@ class LokiEmitter:
             jsonline = json.loads(line) if self.as_json else {}
             for k in self.props_to_labels:
                 if prop_value := getattr(record, k, None) or jsonline.get(k, None):
-                    extra_tags.update({k: prop_value})
+                    if isinstance(self.props_to_labels, list):
+                        extra_tags.update({k: prop_value})
+                    else:
+                        extra_tags.update({self.props_to_labels[k]: prop_value})
         if isinstance(passed_tags := getattr(record, "tags", {}), dict):
             extra_tags = extra_tags | passed_tags
 


### PR DESCRIPTION
I don't know if you are ready to accept PR, but it seems you are about to push this project to `pypi` and as the source project is not maintained since 5 years, I will take my chance here.

This PR : 

- Fix bug using `props_to_labels` in non json mode
- Fix bug when the property in the log record is not a string as loki API accept only string values
- Add ability to change the name of the properties to be sent as labels to loki

This will allow for instance, to use `LoggingInstrumentor().instrument()` from opentelemetry and translate all `otel*` log record properties to something more common (trace_id, span_id, ...)